### PR TITLE
Fixed returned value when ENV variable is defined but is empty

### DIFF
--- a/env.go
+++ b/env.go
@@ -73,7 +73,7 @@ func GetBytes(key string, defaultValue []byte) []byte {
 
 func GetStringSlice(key string, defaultValue []string) []string {
 	value, exists := os.LookupEnv(key)
-	if !exists {
+	if !exists || value == "" {
 		return defaultValue
 	}
 

--- a/env_test.go
+++ b/env_test.go
@@ -172,21 +172,20 @@ func TestGetStringSlice(t *testing.T) {
 		assert.Equal(t, expected, result)
 	})
 
+	t.Run("When the key exists but is empty", func(t *testing.T) {
+		key, value := "KEY", ""
+		t.Setenv(key, value)
+
+		result := GetStringSlice(key, nil)
+
+		assert.Nil(t, result)
+	})
+
 	t.Run("When the key does not exist", func(t *testing.T) {
 		key, defaultValue := "KEY", []string{"DEFAULT"}
 		expected := defaultValue
 
 		result := GetStringSlice(key, defaultValue)
-
-		assert.Equal(t, expected, result)
-	})
-
-	t.Run("When the key exists but is empty", func(t *testing.T) {
-		key, value := "KEY", ""
-		expected := []string{""}
-		t.Setenv(key, value)
-
-		result := GetStringSlice(key, nil)
 
 		assert.Equal(t, expected, result)
 	})


### PR DESCRIPTION
This pull request updates the behavior of the `GetStringSlice` function to treat empty environment variable values as equivalent to unset values, returning the provided default in both cases. It also updates the related tests to reflect this new logic and ensures proper handling of nil results.

**Behavioral change to environment variable parsing:**

* Modified `GetStringSlice` in `env.go` to return the default value when the environment variable is either unset or set to an empty string, instead of only when it is unset.

**Test updates:**

* Updated `TestGetStringSlice` in `env_test.go` to reflect the new behavior: the test for an empty environment variable now expects a nil result, and the order of test cases was adjusted for clarity.